### PR TITLE
Update the Python Request approach and more

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-SSLify>=0.1.5
 flake8>=3.5.0
 requests>=2.20.0
 gunicorn>=19.9.0
+pyOpenSSL>=19.9.0

--- a/utils/rest.py
+++ b/utils/rest.py
@@ -20,7 +20,17 @@ class RestUtil:
 
     @staticmethod
     def execute_get(url, body=None, headers=None):
-        rest_response = requests.get(url, headers=headers, json=body)
+        print("#####")
+        print("url: {}".format(url))
+        print("header: {}".format(headers))
+        print("body: {}".format(body))
+        try:
+            # rest_response = requests.get(url, headers=headers, json=body)
+            rest_response = requests.request("GET", url, headers=headers)
+            rest_response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Exception excute_get(): {}".format(e))
+            raise
         return RestUtil.handle_response_as_json(rest_response)
 
     @staticmethod


### PR DESCRIPTION
Not sure if the there is a bug in v2.20.0 (current) versus the latest v2.22.0 but when I flip the approach with `requests.request('GET', ..)` instead of `requests.get('...')`. It's weird bc I think .get() is just alias for the rq.request('GET'...) from what I saw in the documentation. 

https://requests.kennethreitz.org/en/master/_modules/requests/api/#request

I am wondering if the session object is lost or something so you get a 403 and maybe ASGI on bean stalk is doing some header stuff. Just not sure and don't want to waste more cycle on this. 

So if you start refactoring to `requests.request("GET",...)` it should work for the rest. Plus I add some best-practice technique with Request. =)

